### PR TITLE
Fix jecs string require

### DIFF
--- a/lib/utilities/observers.luau
+++ b/lib/utilities/observers.luau
@@ -22,7 +22,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 ]]
-local jecs = require("@pkg/jecs")
+local jecs = require("../../jecs")
 
 export type PatchedWorld = jecs.World & {
     added: <T>(PatchedWorld, jecs.Id<T>, (e: jecs.Entity, id: jecs.Id, value: T) -> ()) -> () -> (),


### PR DESCRIPTION
Fixed an issue where false `@pkg` alias directory was being required.